### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,12 +14,12 @@ Imports:
     methods,
     Formula,
     Rcpp (>= 0.12.0),
-    rstan (>= 2.18.1)
+    rstan (>= 2.26.0)
 LinkingTo: 
     BH (>= 1.66.0),
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 RoxygenNote: 7.1.0

--- a/R/cbq.R
+++ b/R/cbq.R
@@ -268,7 +268,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset
+            input_offset = offset
             )
         } else if (type == "random") {
             stanmodel = stanmodels$cbqrandombv
@@ -278,7 +278,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_person = length(unique(random_var)),
             person = random_var
             )
@@ -290,7 +290,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_wave = length(unique(fixed_var)),
             wave = fixed_var
             )
@@ -302,7 +302,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_wave = length(unique(fixed_var)),
             wave = fixed_var,
             N_person = length(unique(random_var)),
@@ -318,7 +318,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset
+            input_offset = offset
             )
         } else if (type == "random") {
             stanmodel = stanmodels$cbqrandomb
@@ -328,7 +328,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_person = length(unique(random_var)),
             person = random_var
             )
@@ -340,7 +340,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_wave = length(unique(fixed_var)),
             wave = fixed_var
             )
@@ -352,7 +352,7 @@ cbq <- function(formula,
             D = n_covariate,
             X = x,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_wave = length(unique(fixed_var)),
             wave = fixed_var,
             N_person = length(unique(random_var)),
@@ -374,7 +374,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset
+            input_offset = offset
             )
         } else if (type == "random") {
             x <- x[order(indx, y), ]
@@ -389,7 +389,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_person = length(unique(random_var)),
             person = random_var
             )
@@ -406,7 +406,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_wave = length(unique(fixed_var)),
             wave = fixed_var
             )
@@ -424,7 +424,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_person = length(unique(random_var)),
             person = random_var,
             N_wave = length(unique(fixed_var)),
@@ -445,7 +445,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset
+            input_offset = offset
             )
         } else if (type == "random") {
             x <- x[order(indx, y), ]
@@ -460,7 +460,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_person = length(unique(random_var)),
             person = random_var
             )
@@ -477,7 +477,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_wave = length(unique(fixed_var)),
             wave = fixed_var
             )
@@ -495,7 +495,7 @@ cbq <- function(formula,
             N_indx = length(unique(indx)),
             ind = indx,
             q = q,
-            offset = offset,
+            input_offset = offset,
             N_person = length(unique(random_var)),
             person = random_var,
             N_wave = length(unique(fixed_var)),

--- a/inst/stan/cbqb.stan
+++ b/inst/stan/cbqb.stan
@@ -15,7 +15,7 @@ data {
   int D;
   vector<lower=-1,upper=1>[N] Y;
   matrix[N,D] X; 
-  real offset;
+  real input_offset;
   real<lower = 0, upper = 1> q;
 }
 
@@ -32,10 +32,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = pald2((dot_product(X[i,],beta)),q) + offset;  
+      lik = pald2((dot_product(X[i,],beta)),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = 1 - pald2((dot_product(X[i,],beta)),q) + offset;  
+      lik = 1 - pald2((dot_product(X[i,],beta)),q) + input_offset;  
     }
     target += log(lik);
   }

--- a/inst/stan/cbqbv.stan
+++ b/inst/stan/cbqbv.stan
@@ -18,7 +18,7 @@ data {
   vector<lower=-1,upper=1>[N] Y; 
   matrix[N,D] X; 
   real q;
-  real offset;
+  real input_offset;
 }
 
 
@@ -33,10 +33,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = 1 - pald2(-(dot_product(X[i,],beta)),q) + offset;  
+      lik = 1 - pald2(-(dot_product(X[i,],beta)),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = pald2(-(dot_product(X[i,],beta)),q) + offset;  
+      lik = pald2(-(dot_product(X[i,],beta)),q) + input_offset;  
     }
 
     target += log(lik);

--- a/inst/stan/cbqd.stan
+++ b/inst/stan/cbqd.stan
@@ -9,7 +9,7 @@ functions{
     return(prob);
   }
 
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -18,11 +18,11 @@ functions{
       return count;
   }
 
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input")
+      reject("illegal input");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -42,13 +42,13 @@ data {
 	vector<lower=-1,upper=1>[N] Y;
 	matrix[N,D_common] X_common;
 	int N_indx; 
-	int ind[N]; 
-  real offset;
+	array[N] int ind; 
+  real input_offset;
   real<lower = 0, upper = 1> q;
 }
 
 transformed data{
-  int n_group[N_indx]; 
+  array[N_indx] int n_group; 
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -97,7 +97,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-     	lik2 = rising_factorial(n_group[i],0) * (lik+offset) * lik3;
+     	lik2 = rising_factorial(n_group[i],0) * (lik+input_offset) * lik3;
      	target += log(lik2);
      	pos = pos + n_group[i];
   }

--- a/inst/stan/cbqdv.stan
+++ b/inst/stan/cbqdv.stan
@@ -9,7 +9,7 @@ functions{
     return(prob);
   }
 
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -18,11 +18,11 @@ functions{
       return count;
   }
 
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input")
+      reject("illegal input");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -42,13 +42,13 @@ data {
 	vector<lower=-1,upper=1>[N] Y;
 	matrix[N,D_common] X_common;
 	int N_indx; 
-	int ind[N]; 
-  real offset;
+	array[N] int ind; 
+  real input_offset;
   real<lower = 0, upper = 1> q;
 }
 
 transformed data{
-  int n_group[N_indx]; 
+  array[N_indx] int n_group; 
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -97,7 +97,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-     	lik2 = rising_factorial(n_group[i],0) * (lik+offset) * lik3;
+     	lik2 = rising_factorial(n_group[i],0) * (lik+input_offset) * lik3;
      	target += log(lik2);
      	pos = pos + n_group[i];
   }

--- a/inst/stan/cbqfixb.stan
+++ b/inst/stan/cbqfixb.stan
@@ -15,10 +15,10 @@ data {
   int D;
   vector<lower=-1,upper=1>[N] Y;
   matrix[N,D] X; 
-  real offset;
+  real input_offset;
   real<lower = 0, upper = 1> q;
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
 }
 
 
@@ -35,10 +35,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = pald2((dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + offset;  
+      lik = pald2((dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = 1 - pald2((dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + offset;  
+      lik = 1 - pald2((dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + input_offset;  
     }
     target += log(lik);
   }

--- a/inst/stan/cbqfixbv.stan
+++ b/inst/stan/cbqfixbv.stan
@@ -15,10 +15,10 @@ data {
   int D;
   vector<lower=-1,upper=1>[N] Y;
   matrix[N,D] X; 
-  real offset;
+  real input_offset;
   real<lower = 0, upper = 1> q;
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
 }
 
 
@@ -35,10 +35,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = 1 - pald2(-(dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + offset;  
+      lik = 1 - pald2(-(dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = pald2(-(dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + offset;  
+      lik = pald2(-(dot_product(X[i,],beta) + beta_wave[wave[i]]),q) + input_offset;  
     }
     target += log(lik);
   }

--- a/inst/stan/cbqfixd.stan
+++ b/inst/stan/cbqfixd.stan
@@ -11,7 +11,7 @@ return(prob);
 }
 
 //## function to return the number of observations in a group
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -21,11 +21,11 @@ return(prob);
   }
   
   //## function to subset an integer array (return just those observations in a given group)
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input: non-matching dimensions")
+      reject("illegal input: non-matching dimensions");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -48,17 +48,17 @@ data {
 	vector<lower=-1,upper=1>[N] Y; //# data of choices y = 0 -> -1, y = 1 -> 1
 	matrix[N,D_common] X_common; //# common covariates
 	int N_indx; //# number of groups
-	int ind[N]; //# group index
+	array[N] int ind; //# group index
   // int N_person; // number of individuals
   // int person[N]; // person index
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
   real q; // quantile
-  real offset;
+  real input_offset;
 }
 
 transformed data{
-  int n_group[N_indx]; //# number of observations in the group
+  array[N_indx] int n_group; //# number of observations in the group
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -124,7 +124,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-      lik2 = (lik + offset) * lik3;
+      lik2 = (lik + input_offset) * lik3;
 
      	target += log(lik2);
      	pos = pos + n_group[i];

--- a/inst/stan/cbqfixdv.stan
+++ b/inst/stan/cbqfixdv.stan
@@ -11,7 +11,7 @@ return(prob);
 }
 
 //## function to return the number of observations in a group
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -21,11 +21,11 @@ return(prob);
   }
   
   //## function to subset an integer array (return just those observations in a given group)
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input: non-matching dimensions")
+      reject("illegal input: non-matching dimensions");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -48,17 +48,17 @@ data {
 	vector<lower=-1,upper=1>[N] Y; //# data of choices y = 0 -> -1, y = 1 -> 1
 	matrix[N,D_common] X_common; //# common covariates
 	int N_indx; //# number of groups
-	int ind[N]; //# group index
+	array[N] int ind; //# group index
   // int N_person; // number of individuals
   // int person[N]; // person index
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
   real q; // quantile
-  real offset;
+  real input_offset;
 }
 
 transformed data{
-  int n_group[N_indx]; //# number of observations in the group
+  array[N_indx] int n_group; //# number of observations in the group
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -124,7 +124,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-      lik2 = (lik + offset) * lik3;
+      lik2 = (lik + input_offset) * lik3;
 
      	target += log(lik2);
      	pos = pos + n_group[i];

--- a/inst/stan/cbqpanelb.stan
+++ b/inst/stan/cbqpanelb.stan
@@ -15,12 +15,12 @@ data {
   int D;
   vector<lower=-1,upper=1>[N] Y;
   matrix[N,D] X; 
-  real offset;
+  real input_offset;
   real<lower = 0, upper = 1> q;
   int N_person; // number of individuals
-  int person[N]; // person index
+  array[N] int person; // person index
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
 }
 
 
@@ -42,10 +42,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = pald2((dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + offset;  
+      lik = pald2((dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = 1 - pald2((dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + offset;  
+      lik = 1 - pald2((dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + input_offset;  
     }
     target += log(lik);
   }

--- a/inst/stan/cbqpanelbv.stan
+++ b/inst/stan/cbqpanelbv.stan
@@ -15,12 +15,12 @@ data {
   int D;
   vector<lower=-1,upper=1>[N] Y;
   matrix[N,D] X; 
-  real offset;
+  real input_offset;
   real<lower = 0, upper = 1> q;
   int N_person; // number of individuals
-  int person[N]; // person index
+  array[N] int person; // person index
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
 }
 
 
@@ -42,10 +42,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = 1 - pald2((dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + offset;  
+      lik = 1 - pald2((dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = pald2(-(dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + offset;  
+      lik = pald2(-(dot_product(X[i,],beta) + beta_ind[person[i]] + beta_wave[wave[i]]),q) + input_offset;  
     }
     target += log(lik);
   }

--- a/inst/stan/cbqpaneld.stan
+++ b/inst/stan/cbqpaneld.stan
@@ -11,7 +11,7 @@ return(prob);
 }
 
 //## function to return the number of observations in a group
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -21,11 +21,11 @@ return(prob);
   }
   
   //## function to subset an integer array (return just those observations in a given group)
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input: non-matching dimensions")
+      reject("illegal input: non-matching dimensions");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -48,17 +48,17 @@ data {
 	vector<lower=-1,upper=1>[N] Y; //# data of choices y = 0 -> -1, y = 1 -> 1
 	matrix[N,D_common] X_common; //# common covariates
 	int N_indx; //# number of groups
-	int ind[N]; //# group index
+	array[N] int ind; //# group index
   int N_person; // number of individuals
-  int person[N]; // person index
+  array[N] int person; // person index
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
   real q; // quantile
-  real offset;
+  real input_offset;
 }
 
 transformed data{
-  int n_group[N_indx]; //# number of observations in the group
+  array[N_indx] int n_group; //# number of observations in the group
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -124,7 +124,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-      lik2 = (lik + offset) * lik3;
+      lik2 = (lik + input_offset) * lik3;
 
      	target += log(lik2);
      	pos = pos + n_group[i];

--- a/inst/stan/cbqpaneldv.stan
+++ b/inst/stan/cbqpaneldv.stan
@@ -11,7 +11,7 @@ return(prob);
 }
 
 //## function to return the number of observations in a group
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -21,11 +21,11 @@ return(prob);
   }
   
   //## function to subset an integer array (return just those observations in a given group)
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input: non-matching dimensions")
+      reject("illegal input: non-matching dimensions");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -48,17 +48,17 @@ data {
 	vector<lower=-1,upper=1>[N] Y; //# data of choices y = 0 -> -1, y = 1 -> 1
 	matrix[N,D_common] X_common; //# common covariates
 	int N_indx; //# number of groups
-	int ind[N]; //# group index
+	array[N] int ind; //# group index
   int N_person; // number of individuals
-  int person[N]; // person index
+  array[N] int person; // person index
   int N_wave; // number of waves
-  int wave[N];// wave index
+  array[N] int wave;// wave index
   real q; // quantile
-  real offset;
+  real input_offset;
 }
 
 transformed data{
-  int n_group[N_indx]; //# number of observations in the group
+  array[N_indx] int n_group; //# number of observations in the group
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -124,7 +124,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-      lik2 = (lik+offset) * lik3;
+      lik2 = (lik+input_offset) * lik3;
 
      	target += log(lik2);
      	pos = pos + n_group[i];

--- a/inst/stan/cbqrandomb.stan
+++ b/inst/stan/cbqrandomb.stan
@@ -16,8 +16,8 @@ data {
   vector<lower=-1,upper=1>[N] Y;
   matrix[N,D] X; 
   int N_person; // number of individuals
-  int person[N]; // person index
-  real offset;
+  array[N] int person; // person index
+  real input_offset;
   real<lower = 0, upper = 1> q;
 }
 
@@ -36,10 +36,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = pald2((dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + offset;  
+      lik = pald2((dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = 1 - pald2((dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + offset;  
+      lik = 1 - pald2((dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + input_offset;  
     }
     target += log(lik);
   }

--- a/inst/stan/cbqrandombv.stan
+++ b/inst/stan/cbqrandombv.stan
@@ -16,8 +16,8 @@ data {
   vector<lower=-1,upper=1>[N] Y;
   matrix[N,D] X; 
   int N_person; // number of individuals
-  int person[N]; // person index
-  real offset;
+  array[N] int person; // person index
+  real input_offset;
   real<lower = 0, upper = 1> q;
 }
 
@@ -36,10 +36,10 @@ model{
 
   for (i in 1:N){
     if (Y[i] == 1){
-      lik = 1 - pald2(-(dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + offset;  
+      lik = 1 - pald2(-(dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + input_offset;  
     }
     if (Y[i] == 0){
-      lik = pald2(-(dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + offset;  
+      lik = pald2(-(dot_product(X[i,],beta) + beta_ind[person[i]] ),q) + input_offset;  
     }
     target += log(lik);
   }

--- a/inst/stan/cbqrandomd.stan
+++ b/inst/stan/cbqrandomd.stan
@@ -11,7 +11,7 @@ return(prob);
 }
 
 //## function to return the number of observations in a group
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -21,11 +21,11 @@ return(prob);
   }
   
   //## function to subset an integer array (return just those observations in a given group)
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input: non-matching dimensions")
+      reject("illegal input: non-matching dimensions");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -48,17 +48,17 @@ data {
 	vector<lower=-1,upper=1>[N] Y; //# data of choices y = 0 -> -1, y = 1 -> 1
 	matrix[N,D_common] X_common; //# common covariates
 	int N_indx; //# number of groups
-	int ind[N]; //# group index
+	array[N] int ind; //# group index
   int N_person; // number of individuals
-  int person[N]; // person index
+  array[N] int person; // person index
   // int N_wave; // number of waves
   // int wave[N];// wave index
   real q; // quantile
-  real offset;
+  real input_offset;
 }
 
 transformed data{
-  int n_group[N_indx]; //# number of observations in the group
+  array[N_indx] int n_group; //# number of observations in the group
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -124,7 +124,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-      lik2 = (lik + offset) * lik3;
+      lik2 = (lik + input_offset) * lik3;
 
      	target += log(lik2);
      	pos = pos + n_group[i];

--- a/inst/stan/cbqrandomdv.stan
+++ b/inst/stan/cbqrandomdv.stan
@@ -11,7 +11,7 @@ return(prob);
 }
 
 //## function to return the number of observations in a group
-  int group_size(int[] ref, int value) {
+  int group_size(array[] int ref, int value) {
     int count;
     count = 0;
     for (ii in 1:size(ref))
@@ -21,11 +21,11 @@ return(prob);
   }
   
   //## function to subset an integer array (return just those observations in a given group)
-  int[] subset_intarray(int[] y, int[] ref, int value) {
+  array[] int subset_intarray(array[] int y, array[] int ref, int value) {
     int jj;
-    int res[group_size(ref, value)];
+    array[group_size(ref, value)] int res;
     if (size(ref) != size(y))
-      reject("illegal input: non-matching dimensions")
+      reject("illegal input: non-matching dimensions");
     jj = 1;
     for(ii in 1:size(ref)) {
       if (ref[ii] == value) {
@@ -48,17 +48,17 @@ data {
 	vector<lower=-1,upper=1>[N] Y; //# data of choices y = 0 -> -1, y = 1 -> 1
 	matrix[N,D_common] X_common; //# common covariates
 	int N_indx; //# number of groups
-	int ind[N]; //# group index
+	array[N] int ind; //# group index
   int N_person; // number of individuals
-  int person[N]; // person index
+  array[N] int person; // person index
   // int N_wave; // number of waves
   // int wave[N];// wave index
   real q; // quantile
-  real offset;
+  real input_offset;
 }
 
 transformed data{
-  int n_group[N_indx]; //# number of observations in the group
+  array[N_indx] int n_group; //# number of observations in the group
   for (ii in 1:N_indx) {
     n_group[ii] = group_size(ind, ii);
   }
@@ -124,7 +124,7 @@ model{
         lik3 = lik3*(1-lik0);
       }
 
-      lik2 = (lik + offset) * lik3;
+      lik2 = (lik + input_offset) * lik3;
 
      	target += log(lik2);
      	pos = pos + n_group[i];


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `offset` is a reserved keyword, changed to `input_offset`
- `cov_exp_quad` replaced by `gp_exp_quad_cov`

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `offset` is a reserved keyword, changed to `input_offset`

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!

Let me know if you have any questions about these changes.

Thanks!
